### PR TITLE
Better error messages on close

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -56,13 +56,16 @@ export class EvaluatorImpl implements Evaluator {
   moduleReaders: ModuleReader[] = []
   randState: bigint;
 
-  constructor(private evaluatorId: bigint, private manager: EvaluatorManager) {
+  constructor(public evaluatorId: bigint, private manager: EvaluatorManager) {
     this.pendingRequests = new Map()
     this.randState = evaluatorId
   }
 
   close(): void {
-    this.manager.close()
+    if (this.closed) {
+      return
+    }
+    return this.manager.closeEvaluator(this)
   }
 
   async evaluateExpression<T>(source: ModuleSource, expr: string): Promise<Any> {


### PR DESCRIPTION
This brings more in line with the go impl; exec manager tracks if it has exited and won't try to send stuff if it has, evaluators can close themselves at which point they will throw sensible errors if you try to use them.