### PR TITLE
Fix property error when subclassing an open class

### DIFF
--- a/codegen/snippet-tests/input/04-withClass.pkl
+++ b/codegen/snippet-tests/input/04-withClass.pkl
@@ -29,3 +29,11 @@ class MyConcreteClass extends MyAbstractClass {
   overridableUnion1: String|Int
   overridableUnion2: String
 }
+
+open class MyOpenClass {
+  someString: String
+}
+
+class MySubclassOfOpen extends MyOpenClass {
+  someInt: Int
+}

--- a/codegen/snippet-tests/output/04_with_class.pkl.ts
+++ b/codegen/snippet-tests/output/04_with_class.pkl.ts
@@ -54,6 +54,16 @@ export interface MyConcreteClass extends MyAbstractClass {
   overridableUnion2: string
 }
 
+// Ref: Pkl class `04-withClass.MyOpenClass`.
+export interface MyOpenClass {
+  someString: string
+}
+
+// Ref: Pkl class `04-withClass.MySubclassOfOpen`.
+export interface MySubclassOfOpen extends MyOpenClass {
+  someInt: number
+}
+
 // LoadFromPath loads the pkl module at the given path and evaluates it into a N04WithClass
 export const loadFromPath = async (path: string): Promise<N04WithClass> => {
   const evaluator = await pklTypescript.newEvaluator(pklTypescript.PreconfiguredOptions);

--- a/codegen/src/internal/ClassGen.pkl
+++ b/codegen/src/internal/ClassGen.pkl
@@ -161,13 +161,6 @@ local interface: String = new Listing {
     + "{"
   )
 
-  when (isSuperOpen) {
-    // TODO(Jason): what was this for?
-    // "\t" + superClass!!.struct.type.render(classInfo.goPackage)
-    when (!properties.isEmpty) {
-      ""
-    }
-  }
   for (pklPropertyName, field in fields) {
     when (pklPropertyName != fields.keys.first) {
       ""


### PR DESCRIPTION
Closes: https://github.com/pkl-community/pkl-typescript/issues/54

I believe this snippet was copied over from the Go implementation, but never used - and not noticed without test coverage for it.

Thanks to @gregory-essertel-ai for reporting.